### PR TITLE
Fixing minor issues to make test commnds run

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "watch": "webpack -w",
     "start": "live-server",
     "test": "babel-tape-runner test/*-test.js",
-    "browser-test": "browserify test/*-test.js -t [ babelify --presets [ es2015 react ] ] | tape-run"
+    "browser-test": "browserify test/*-test.js -t [ babelify --presets [ es2015 react ] ] -u 'react/lib/ReactContext' -u 'react/lib/ExecutionEnvironment' | tape-run"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jsdom": "^7.2.1",
     "live-server": "^0.9.0",
     "phantomjs": "^1.9.19",
+    "react-addons-test-utils": "^0.14.5",
     "tape": "^4.2.2",
     "tape-run": "^2.1.0",
     "testling": "^1.7.1",


### PR DESCRIPTION
1. Enyzme requires [`react-addons-test-utils`](https://github.com/airbnb/enzyme#installation) to be installed.
2. When I tried to run `npm run browser-test` it failed with this error _running node 5.1.1_

``` sh
> testing-react@1.0.0 browser-test /Users/Gabri/Sites/trunk/todo-react-testing
> browserify test/*-test.js -t [ babelify --presets [ es2015 react ] ]  | tape-run

Error: Cannot find module 'react/lib/ReactContext' from '/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/enzyme/build'
    at /Users/Gabri/Sites/trunk/todo-react-testing/node_modules/resolve/lib/async.js:46:17
    at process (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/resolve/lib/async.js:173:43)
    at ondir (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/resolve/lib/async.js:188:17)
    at load (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/resolve/lib/async.js:92:31)
    at /Users/Gabri/Sites/trunk/todo-react-testing/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:82:15)
stream.js:74
      throw er; // Unhandled stream error in pipe.
      ^

Error: javascript required
    at Stream.<anonymous> (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/browser-run/index.js:27:34)
    at _end (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/through/index.js:65:9)
    at Stream.stream.end (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/through/index.js:74:5)
    at Stream.method [as end] (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/duplexer/index.js:51:39)
    at Stream.<anonymous> (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/throughout/index.js:7:25)
    at _end (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/through/index.js:65:9)
    at Stream.stream.end (/Users/Gabri/Sites/trunk/todo-react-testing/node_modules/through/index.js:74:5)
    at Stream.onend (stream.js:59:10)
    at emitNone (events.js:72:20)
    at Stream.emit (events.js:166:7)
```

a quick search lead me to this [issue](https://github.com/glenjamin/skin-deep/issues/10) so I excluded `react/lib/ReactContext` & `react/lib/ExecutionEnvironment` from browserify and now the test is working.
